### PR TITLE
Standalone opplot function and demo w/ new features

### DIFF
--- a/Demo/opplot_demo.R
+++ b/Demo/opplot_demo.R
@@ -31,7 +31,7 @@ library(dplyr); library(stringr); library(ggplot2); library(doBy)
 dir <- "C:/Users/clary/Biostat Global Dropbox/Caitlin Clary/CBC GitHub Repos/organ-pipe-plots-R/"
 
 # Source the opplot.R function
-source(paste0(dir, "opplot_dev.R"))
+source(paste0(dir, "opplot.R"))
 
 # Read in data for plotting
 inData <- read.csv(file = paste0(dir, "Demo/testdata_indiv_level.csv"),

--- a/Demo/opplot_demo.R
+++ b/Demo/opplot_demo.R
@@ -1,214 +1,334 @@
-##############################################################################
 # Program:     opplot_demo.r
 # Purpose:     Demonstrate making organ pipe plots
 # Author:      Mary Prier, Biostat Global Consulting
-#              Caitlin Clary, Biostat Global Consulting
+#              Caitlin B. Clary, Biostat Global Consulting
+
 # Delivered:   2017-01-28
 # Updated:     2019-03-26
 #              2020-08-05       Demo updated function
-#
+#              2024-10-08       Update demo examples, including new features
+
 # Input Data:  testdata_indiv_level.csv
 # Required Functions: opplot.R
-# Required Packages: doBy
-###############################################################################
+# Required Packages: dplyr, stringr, ggplot2, doBy
+
+# Note: see the end of this R file for comments explaining each argument to the
+# opplot function
+
+# Setup ----
 
 # Get needed packages if not already installed
-if("doBy" %in% rownames(installed.packages()) == FALSE){
-  install.packages("doBy")}
+pkg_list <- c("dplyr", "stringr", "ggplot2", "doBy")
+for(i in seq_along(pkg_list)){
+  if (!pkg_list[i] %in% rownames(installed.packages())){install.packages(pkg_list[i])}
+}
 
 # Load required packages
-library(doBy)
+library(dplyr); library(stringr); library(ggplot2); library(doBy)
+
+# Define directory where organ pipe plot function and demo data are saved
+# Modify this line to use the right path on your computer!
+dir <- "C:/Users/clary/Biostat Global Dropbox/Caitlin Clary/CBC GitHub Repos/organ-pipe-plots-R/"
 
 # Source the opplot.R function
-# Change this file path to point to the program's location on your computer
-source("C:/Documents/organ-pipe-plots-R/opplot.R")
+source(paste0(dir, "opplot_dev.R"))
 
-# Set file paths (change paths to point to directories on your computer)
-  # inPath = directory holding the data
-  inPath <- file.path("C:/Documents/organ-pipe-plots-R/Demo")
-  # outPath = where to save output
-  outPath <- file.path("C:/Documents/organ-pipe-plots-R/Demo")
+# Read in data for plotting
+inData <- read.csv(file = paste0(dir, "Demo/testdata_indiv_level.csv"),
+                   header = TRUE)
 
-  # To save output in the right location, set working directory to outPath
-  setwd(outPath)
+# Plot examples ----
 
-  # Read in data for plotting
-  inData <- read.csv(file = file.path(inPath,"testdata_indiv_level.csv"),
-                     header = TRUE)
+## Example 1 ----
+## Plot stratum A with default appearance options, output plot to screen
 
-  ## Plotting Examples
+opplot(
+  dat = inData, stratvar = "stratum", clustvar = "clusterid", yvar = "y",
+  stratum = "Stratum A", output_to_screen = TRUE
+)
 
-  # Example 1 ----
-  # All function options are listed, default appearance options selected.
-  # Plots to screen, does not save plot to disk (output_to_screen = TRUE).
+## Example 2 ----
+## Add title, subtitle, and footnote; add line showing # of respondents per cluster
 
-  opplot(dat = inData, stratvar = "stratum", clustvar = "clusterid",
-         weightvar = "svyweight", yvar = "y", stratum = "Stratum A",
-         barcolor1 = "hot pink", barcolor2 = "white",
-         linecolor1 = "gray", linecolor2 = "gray",
-         ylabel = "Percent of Cluster",
-         ymin = 0, ymax = 100, yby = 50,
-         title = "This is the title line",
-         subtitle = "This is the subtitle line",
-         footnote = "Footnote",
-         output_to_screen = TRUE, filename = file.path(outPath, "test2"),
-         platform = "pdf", sizew = 7, sizeh = 6, savedata = "",
-         plotn = FALSE, nlinecolor = "black", nlinewidth = 1, nlinepattern = 2,
-         ytitle2 = "Number of Respondents", yround2 = 5)
+opplot(
+  dat = inData, stratvar = "stratum", clustvar = "clusterid", yvar = "y",
+  stratum = "Stratum A", output_to_screen = TRUE,
 
-  # Example 2 ----
-  # Modifying example 1 plot to include cluster sample size (plotn = TRUE).
+  title = "Stratum A",
+  subtitle = "Coverage and respondents per cluster",
+  footnote = "Dashed line indicates respondents per cluster; see Y axis on the right side of the plot.",
 
-  opplot(dat = inData, stratvar = "stratum", clustvar = "clusterid",
-         weightvar = "svyweight", yvar = "y", stratum = "Stratum A",
-         barcolor1 = "hot pink", barcolor2 = "white",
-         linecolor1 = "gray", linecolor2 = "gray",
-         ylabel = "Percent of Cluster",
-         ymin = 0, ymax = 100, yby = 50,
-         title = "This is the title line",
-         subtitle = "This is the subtitle line",
-         footnote = "Footnote",
-         output_to_screen = TRUE, filename = file.path(outPath, "test2"),
-         platform = "pdf", sizew = 7, sizeh = 6, savedata = "",
-         plotn = TRUE, nlinecolor = "black", nlinewidth = 1, nlinepattern = 2,
-         ytitle2 = "Number of Respondents", yround2 = 5)
+  plotn = TRUE
+)
 
-  # Example 3 ----
-  # Minimal example, plotting clusters in all strata in dataset (stratvar and
-  # stratum arguments are not provided, so all strata are used).
-  # Because of the number of clusters, this plot is not very readable.
+## Example 3 ----
+## Plot stratum C, defining high and low coverage thresholds
 
-  opplot(dat = inData, clustvar = "clusterid", yvar = "y")
+opplot(
+  dat = inData, stratvar = "stratum", clustvar = "clusterid", yvar = "y",
+  stratum = "Stratum C", output_to_screen = TRUE,
 
-  # Example 4 ----
-  # Modifying example 3 plot, increasing plot dimensions to improve legibility.
+  title = "Stratum C",
+  subtitle = "Coverage and respondents per cluster",
+  footnote = "Dashed line indicates respondents per cluster; see Y axis on the right side of the plot.",
 
-  opplot(dat = inData, clustvar = "clusterid", yvar = "y",
-         sizew = 20, sizeh = 12)
+  plotn = TRUE,
 
-  # Example 5 ----
-  # Minimal example, plotting a single stratum (stratum = "Stratum A").
-  # stratvar = "stratum" is provided so the function can identify the
-  # observations belonging to stratum A. No weights are used (no weightvar
-  # argument in this function call).
+  covgcategories = TRUE,
+  lowcovgthreshold = 40,
+  highcovgthreshold = 80
+)
 
-  opplot(dat = inData, clustvar = "clusterid", yvar = "y",
-         stratvar = "stratum", stratum = "Stratum A")
+## Example 4 ----
+## Add lines indicating coverage thresholds and customize line color. Note that
+## colors can be specified as R color names or as hex color codes.
 
-  # Example 6 ----
-  # Plotting Stratum B, adding weight argument (weightvar = "svyweight"), and
-  # saving plot to disk as a PDF (by specifying the filename, platform, and
-  # output_to_screen arguments).
+opplot(
+  dat = inData, stratvar = "stratum", clustvar = "clusterid", yvar = "y",
+  stratum = "Stratum C", output_to_screen = TRUE,
 
-  opplot(dat = inData, clustvar = "clusterid", yvar = "y", weightvar = "svyweight",
-         stratvar = "stratum", stratum = "Stratum B",
-         filename = "StratumB", platform = "pdf",
-         output_to_screen = FALSE)
+  title = "Stratum C",
+  subtitle = "Coverage and respondents per cluster",
+  footnote = "Dashed line indicates respondents per cluster; see Y axis on the right side of the plot.",
 
-  # Example 7 ----
-  # Plotting Stratum G, saving to disk as a PNG, adding cluster size line
-  # (plotn = TRUE), and changing bar colors with barcolor1 and barcolor2.
+  plotn = TRUE,
 
-  opplot(dat = inData, clustvar = "clusterid", yvar = "y", weightvar = "svyweight",
-         stratvar = "stratum", stratum = "Stratum G",
-         filename = "StratumG", platform = "png",
-         output_to_screen = FALSE,
-         plotn = TRUE, nlinecolor = "black", nlinewidth = 1, nlinepattern = 2,
-         barcolor1 = "#2b84e1",
-         barcolor2 = "#e1e1e1",
-         title = "Organ Pipe Plot: Stratum G")
+  covgcategories = TRUE,
+  lowcovgthreshold = 40,
+  highcovgthreshold = 80,
 
-  # Example 8 ----
-  # Plotting Stratum H, saving to disk as a WMF, changing y axis increments
-  # (yby = 25).
+  lowcovgthresholdline = TRUE,
+  highcovgthresholdline = TRUE,
+  lowcovgthresholdlinecolor = "darkred",
+  highcovgthresholdlinecolor = "forestgreen"
+)
 
-  opplot(dat = inData, clustvar = "clusterid", yvar = "y", weightvar = "svyweight",
-         stratvar = "stratum", stratum = "Stratum H",
-         filename = "StratumH", platform = "wmf",
-         output_to_screen = FALSE,
-         yby = 25,
-         plotn = TRUE, nlinecolor = "black", nlinewidth = 1, nlinepattern = 2,
-         barcolor1 = "#a8737d",
-         barcolor2 = "white",
-         title = "Organ Pipe Plot: Stratum H")
+## Example 5 ----
+## Plotting clusters in *all* strata in dataset - because of the number of
+## clusters, this plot is not very readable!
 
-  # Example 9 ----
-  # Plotting stratum C, changing color (nlinecolor), width (nlinewidth), and
-  # pattern (nlinepattern) of the line showing number of respondents.
+opplot(dat = inData, clustvar = "clusterid", yvar = "y",
+       output_to_screen = TRUE)
 
-  opplot(dat = inData, clustvar = "clusterid", yvar = "y", weightvar = "svyweight",
-         stratvar = "stratum", stratum = "Stratum C",
-         output_to_screen = TRUE,
-         plotn = TRUE, nlinecolor = "grey40", nlinewidth = 2, nlinepattern = 3,
-         barcolor1 = "lightcoral",
-         barcolor2 = "floralwhite",
-         linecolor1 = "white", linecolor2 = "white",
-         title = "Stratum C")
+## Example 6 ----
+## Modify example 2, adding weightvar argument, customize colors and n line appearance
 
-  # Example 10 ----
-  # Plotting stratum D, changing the plot dimensions.
+opplot(
+  dat = inData, stratvar = "stratum", clustvar = "clusterid", yvar = "y",
+  weightvar = "svyweight",
+  stratum = "Stratum A", output_to_screen = TRUE,
 
-  opplot(dat = inData, clustvar = "clusterid", yvar = "y", weightvar = "svyweight",
-         stratvar = "stratum", stratum = "Stratum D",
-         output_to_screen = TRUE,
-         plotn = TRUE, nlinecolor = "grey20", nlinewidth = 1, nlinepattern = 3,
-         sizew = 9, sizeh = 6,
-         barcolor1 = "lightcoral",
-         barcolor2 = "white",
-         linecolor1 = "white", linecolor2 = "grey80",
-         title = "Stratum D")
+  barcolor1 = "#0b5394",
+  barcolor2 = "#cfe2f3",
+  linecolor1 = "#eeeeee",
+  linecolor2 = "#eeeeee",
 
-  # Example 11 ----
-  # Instead of providing stratvar and stratum arguments, instead providing a
-  # filtered dataset with only the stratum of interest. Produces the same plot
-  # as example 10.
+  title = "Stratum A",
+  subtitle = "Coverage and respondents per cluster",
+  footnote = "Dashed line indicates respondents per cluster; see Y axis on the right side of the plot.",
 
-  subset_data <- inData[inData$stratum == "Stratum D",]
+  plotn = TRUE,
+  nlinecolor = "#fff469",
+  nlinewidth = 0.8,
+  nlinepattern = 2
+)
 
-  opplot(dat = subset_data, clustvar = "clusterid", yvar = "y", weightvar = "svyweight",
-         output_to_screen = TRUE,
-         plotn = TRUE, nlinecolor = "grey20", nlinewidth = 1, nlinepattern = 3,
-         sizew = 9, sizeh = 6,
-         barcolor1 = "lightcoral",
-         barcolor2 = "white",
-         linecolor1 = "white", linecolor2 = "grey80",
-         title = "Stratum D")
+## Example 7 ----
+## Plot Stratum D, save to disk as PNG and plot to screen
 
-  # Example 12 ----
-  # The stratum variable can be numeric rather than character. This plot of
-  # stratum 4 is the same as the plot of stratum D in examples 10 and 11.
+opplot(
+  dat = inData, stratvar = "stratum", clustvar = "clusterid", yvar = "y",
+  stratum = "Stratum D", output_to_screen = TRUE,
+  filename = "Q:/opplot_test_example_7",
+  platform = "png",
 
-  # Recode stratum variable as numeric
-  inDataNumeric <- inData
-  inDataNumeric$stratum <- as.numeric(as.factor(inDataNumeric$stratum))
+  title = "Stratum D",
+  subtitle = "Coverage and respondents per cluster",
+  footnote = "Dashed line indicates respondents per cluster; see Y axis on the right side of the plot.",
 
-  opplot(dat = inDataNumeric, clustvar = "clusterid", yvar = "y",
-         weightvar = "svyweight", stratvar = "stratum", stratum = 4,
-         output_to_screen = TRUE,
-         plotn = TRUE, nlinecolor = "grey20", nlinewidth = 1, nlinepattern = 3,
-         sizew = 9, sizeh = 6,
-         barcolor1 = "lightcoral",
-         barcolor2 = "white",
-         linecolor1 = "white", linecolor2 = "grey80",
-         title = "Stratum 4")
+  plotn = TRUE
+)
 
-  # Example 13 ----
-  # Specifying the savedata argument, which creates a .csv dataset with
-  # information on each bar (cluster) in the plot.
+## Example 8 ----
+## Update example 7, this time saving as PDF, changing plot dimensions, and
+## changing Y axis increments, and changing main Y axis title
 
-  opplot(dat = inData, clustvar = "clusterid", yvar = "y", weightvar = "svyweight",
-         stratvar = "stratum", stratum = "Stratum D",
-         output_to_screen = TRUE,
-         savedata = "Stratum_D_data")
+opplot(
+  dat = inData, stratvar = "stratum", clustvar = "clusterid", yvar = "y",
+  stratum = "Stratum D", output_to_screen = TRUE,
+  filename = "Q:/opplot_test_example_8",
+  platform = "pdf",
+  sizew = 12,
+  sizeh = 8,
 
-  # Read in and view the dataset just created
-  strat_D <- read.csv("Stratum_D_data.csv")
-  View(strat_D)
+  ylabel = "Cluster Coverage (%)",
+  yby = 25,
 
-  # Clean up ----
+  title = "Stratum D",
+  subtitle = "Coverage and respondents per cluster",
+  footnote = "Dashed line indicates respondents per cluster; see Y axis on the right side of the plot.",
 
-  # Close all graphics printed to the screen
-  graphics.off()
+  plotn = TRUE
+)
 
-  # Remove data and other objects
-  rm(list = "inPath", "outPath", "inData", "subset_data", "strat_D")
+## Example 9 ----
+## Instead of providing stratvar and stratum arguments, filter the input dataset
+## to contain only the stratum of interest. This approach produces the same plot
+## as example 8.
+
+subset_data <- inData[inData$stratum == "Stratum D",]
+
+opplot(
+  dat = subset_data, clustvar = "clusterid", yvar = "y",
+  output_to_screen = TRUE,
+
+  ylabel = "Cluster Coverage (%)",
+  yby = 25,
+
+  title = "Stratum D",
+  subtitle = "Coverage and respondents per cluster",
+  footnote = "Dashed line indicates respondents per cluster; see Y axis on the right side of the plot.",
+
+  plotn = TRUE
+)
+
+## Example 10 ----
+## The stratum variable can be numeric rather than character. This plot of
+## stratum 4 is the same as the plot of stratum D in examples 8 and 9
+
+# Recode stratum variable as numeric
+inDataNumeric <- inData
+inDataNumeric$stratum <- as.numeric(as.factor(inDataNumeric$stratum))
+
+opplot(
+  dat = inDataNumeric, stratvar = "stratum", clustvar = "clusterid", yvar = "y",
+  stratum = 4, output_to_screen = TRUE,
+
+  ylabel = "Cluster Coverage (%)",
+  yby = 25,
+
+  title = "Stratum D",
+  subtitle = "Coverage and respondents per cluster",
+  footnote = "Dashed line indicates respondents per cluster; see Y axis on the right side of the plot.",
+
+  plotn = TRUE
+)
+
+## Example 11 ----
+## Specifying the savedata argument, which creates a dataset with
+## information on each bar (cluster) in the plot.
+
+opplot(
+  dat = inData, clustvar = "clusterid", yvar = "y", weightvar = "svyweight",
+  stratvar = "stratum", stratum = "Stratum D",
+  output_to_screen = TRUE,
+  savedata = "Q:/opplot_test_example_11_stratum_D_data",
+  savedatatype = "csv"
+)
+
+# Read in and view the dataset just created
+strat_D <- read.csv("Q:/opplot_test_example_11_stratum_D_data.csv")
+View(strat_D)
+
+## Example 12 ----
+## Saving data as a .rds file instead of a .csv
+
+opplot(
+  dat = inData, clustvar = "clusterid", yvar = "y", weightvar = "svyweight",
+  stratvar = "stratum", stratum = "Stratum D",
+  output_to_screen = TRUE,
+  savedata = "Q:/opplot_test_example_11_stratum_D_data",
+  savedatatype = "rds"
+)
+
+# Read in and view the dataset just created
+strat_D <- readRDS("Q:/opplot_test_example_11_stratum_D_data.rds")
+View(strat_D)
+
+# Clean up ----
+
+# Close all graphics printed to the screen
+graphics.off()
+
+# Remove data and other objects
+rm(list = "inData", "inDataNumeric", "subset_data", "strat_D", "dir", "i",
+   "pkg_list", "opplot", "vcqi_check_color")
+
+
+# Notes: function arguments ----
+
+# # Required arguments: dat, clustvar, yvar
+# dat,
+# clustvar,
+# yvar,
+#
+# # Optional arguments
+#
+# ## Define variables with information on weights and strata
+# weightvar = NA,
+# stratvar = NA,
+#
+# ## Specific stratum to plot results for
+# stratum = "",
+#
+# barcolor1 = "hotpink",  # Color for portion of bar where yvar = 1
+# barcolor2 = "white",    # Color for portion of bar where yvar = 1
+# linecolor1 = "gray",    # Color for lines separating lower portion of bars
+# linecolor2 = "gray",    # Color for lines separating upper portion of bars
+#
+# ylabel = "Percent of Cluster",  # Label for y axis
+# ymin = 0,   # Minimum value for Y axis
+# ymax = 100, # Maximum value for Y axis
+# yby = 50,   # Increment for Y axis breaks
+#
+# title = "",    # Title of the plot
+# subtitle = "", # Subtitle of the plot
+# footnote = "", # Footnote of the plot
+#
+# plotn = FALSE,        # Plot a line showing the # of respondents in each cluster
+# nlinecolor = "black", # Color of line indicating # of respondents
+# nlinewidth = 0.75,    # Width of line indicating # of respondents
+# nlinepattern = 2,     # Pattern of line indicating # of respondents
+# ytitle2 = "Number of Respondents", # Label for secondary Y axis
+# yround2 = 5,                       # Increment for secondary Y axis breaks
+#
+# covgcategories = FALSE, # Stratify plot into high, medium, & low coverage categories
+#
+# ## The numeric percent value (0-100) used to identify low coverage; clusters
+# ## with coverage less than or equal to this number will be assigned to the low
+# ## coverage category. Used when covgcategories = TRUE.
+# lowcovgthreshold = NA,
+#
+# ## The numeric percent value (0-100) used to identify high coverage; clusters
+# ## with coverage greater than or equal to this number will be assigned to the
+# ## high coverage category. Used when covgcategories = TRUE.
+# highcovgthreshold = NA,
+#
+# barcolorhigh1 = "#67A9CF", # Color for portion of high coverage bars where yvar = 1
+# barcolormid1 = "#000080",  # Color for portion of medium coverage bars where yvar = 1
+# barcolorlow1 = "#FF5B00",  # Color for portion of low coverage bars where yvar = 1
+# barcolorhigh2 = "#f0f0f0", # Color for portion of high coverage bars where yvar = 0
+# barcolormid2 = "#f0f0f0",  # Color for portion of medium coverage bars where yvar = 0
+# barcolorlow2 = "#f0f0f0",  # Color for portion of low coverage bars where yvar = 0
+#
+# linecolorhigh1 = "gray", # Color for lines separating lower portion of high covg bars
+# linecolormid1 = "gray",  # Color for lines separating lower portion of medium covg bars
+# linecolorlow1 = "gray",  # Color for lines separating lower portion of low covg bars
+# linecolorhigh2 = "gray", # Color for lines separating upper portion of high covg bars
+# linecolormid2 = "gray",  # Color for lines separating upper portion of medium covg bars
+# linecolorlow2 = "gray",  # Color for lines separating upper portion of low covg bars
+#
+# lowcovgthresholdline = FALSE,  # Show line indicating low coverage threshold
+# highcovgthresholdline = FALSE, # Show line indicating high coverage threshold
+#
+# lowcovgthresholdlinecolor = "red",  # Color for lowcovgthresholdline
+# highcovgthresholdlinecolor = "red", # Color for highcovgthresholdline
+#
+# output_to_screen = FALSE,  # Show the plot in plot window?
+# filename = NA_character_,  # Path to save the plot
+# platform = "png", # Type of plot file (may be png, pdf, or wmf)
+# sizew = 7, # Width of the plot file in inches
+# sizeh = 6, # Height of the plot file in inches
+#
+# savedata = NA_character_,  # Path to save underlying data (if NA, data will not be saved)
+# savedatatype = "csv"       # File type for saving underlying data (may be csv or rds)

--- a/opplot.R
+++ b/opplot.R
@@ -1,190 +1,365 @@
-####################################################################################
-# Program:     opplot.R
-# Purpose:     Make organ pipe plot
-# Author:      Mary Prier, Biostat Global Consulting
-# Delivered:   2017-01-28
-# Updated:     2019-03-14 MLP: plotn & savedata options
-#              2020-05-13 CBC: weightvar handling, various checks/warnings
-#                              data.frame assertion at top
-#              2020-05-18 CBC: fix bug in savedata
-#              2020-05-28 CBC: pass dimensions to png, variable name checks
-# Required Packages: doBy
-####################################################################################
+# Organ pipe plot function
+# Produce a bar plot showing coverage in each cluster in a stratum
+
+# Dependencies: dplyr, stringr, ggplot2, doBy
+
+# Function to check color validity
+vcqi_check_color <- function(color){
+  res <- try(col2rgb(color), silent = TRUE)
+  return(!"try-error" %in% class(res))
+}
 
 opplot <- function(
-  ## Required arguments: dat, clustvar, yvar
+  # Required arguments: dat, clustvar, yvar
   dat,
   clustvar,
   yvar,
-  ## Optional arguments:
+
+  # Optional arguments
+
+  ## Define variables with information on weights and strata
   weightvar = NA,
   stratvar = NA,
-  stratum = "",
-  barcolor1 = "hot pink", # color for respondents with yvar = 1
-  barcolor2 = "white",    # color for respondents with yvar = 0
-  linecolor1 = "gray",    # color for lines separating lower portion of bars
-  linecolor2 = "gray",    # color for lines separating upper portion of bars
-  ylabel = "Percent of Cluster",
-  ymin = 0,
-  ymax = 100,
-  yby = 50,
-  title = "",
-  subtitle = "",
-  footnote = "",
-  output_to_screen = TRUE,
-  filename = "",
-  platform = "wmf",
-  sizew = 7,
-  sizeh = 6,
-  plotn = FALSE,
-  nlinecolor = "black",
-  nlinewidth = 1,       # color: line indicating # of respondents
-  nlinepattern = 2,     # pattern: line indicating # of respondents
-  ytitle2 = "Number of Respondents",
-  yround2 = 5,
-  savedata = "")
-{
 
-  ### Ensure data is a data.frame object
+  ## Specific stratum to plot results for
+  stratum = "",
+
+  barcolor1 = "hotpink",  # Color for portion of bar where yvar = 1
+  barcolor2 = "white",    # Color for portion of bar where yvar = 1
+  linecolor1 = "gray",    # Color for lines separating lower portion of bars
+  linecolor2 = "gray",    # Color for lines separating upper portion of bars
+
+  ylabel = "Percent of Cluster",  # Label for y axis
+  ymin = 0,   # Minimum value for Y axis
+  ymax = 100, # Maximum value for Y axis
+  yby = 50,   # Increment for Y axis breaks
+
+  title = "",    # Title of the plot
+  subtitle = "", # Subtitle of the plot
+  footnote = "", # Footnote of the plot
+
+  plotn = FALSE,        # Plot a line showing the # of respondents in each cluster
+  nlinecolor = "black", # Color of line indicating # of respondents
+  nlinewidth = 0.75,    # Width of line indicating # of respondents
+  nlinepattern = 2,     # Pattern of line indicating # of respondents
+  ylabel2 = "Number of Respondents", # Label for secondary Y axis
+  yround2 = 5,                       # Increment for secondary Y axis breaks
+
+  covgcategories = FALSE, # Stratify plot into high, medium, & low coverage categories
+
+  ## The numeric percent value (0-100) used to identify low coverage; clusters
+  ## with coverage less than or equal to this number will be assigned to the low
+  ## coverage category. Used when covgcategories = TRUE.
+  lowcovgthreshold = NA,
+  ## The numeric percent value (0-100) used to identify high coverage; clusters
+  ## with coverage greater than or equal to this number will be assigned to the
+  ## high coverage category. Used when covgcategories = TRUE.
+  highcovgthreshold = NA,
+
+  barcolorhigh1 = "#67A9CF", # Color for portion of high coverage bars where yvar = 1
+  barcolormid1 = "#000080",  # Color for portion of medium coverage bars where yvar = 1
+  barcolorlow1 = "#FF5B00",  # Color for portion of low coverage bars where yvar = 1
+  barcolorhigh2 = "#f0f0f0", # Color for portion of high coverage bars where yvar = 0
+  barcolormid2 = "#f0f0f0",  # Color for portion of medium coverage bars where yvar = 0
+  barcolorlow2 = "#f0f0f0",  # Color for portion of low coverage bars where yvar = 0
+
+  linecolorhigh1 = "gray", # Color for lines separating lower portion of high covg bars
+  linecolormid1 = "gray",  # Color for lines separating lower portion of medium covg bars
+  linecolorlow1 = "gray",  # Color for lines separating lower portion of low covg bars
+  linecolorhigh2 = "gray", # Color for lines separating upper portion of high covg bars
+  linecolormid2 = "gray",  # Color for lines separating upper portion of medium covg bars
+  linecolorlow2 = "gray",  # Color for lines separating upper portion of low covg bars
+
+  lowcovgthresholdline = FALSE,  # Show line indicating low coverage threshold
+  highcovgthresholdline = FALSE, # Show line indicating high coverage threshold
+
+  lowcovgthresholdlinecolor = "red",  # Color for lowcovgthresholdline
+  highcovgthresholdlinecolor = "red", # Color for highcovgthresholdline
+
+  output_to_screen = FALSE,  # Show the plot in plot window?
+  filename = NA_character_,  # Path to save the plot
+  platform = "png", # Type of plot file (may be png, pdf, or wmf)
+  sizew = 7, # Width of the plot file in inches
+  sizeh = 6, # Height of the plot file in inches
+
+  savedata = NA_character_,  # Path to save underlying data (if NA, data will not be saved)
+  savedatatype = "csv"       # File type for saving underlying data (may be csv or rds)
+){
+
+  # Ensure data is a data.frame object
   dat <- as.data.frame(dat)
 
-  ### Check variable name arguments
-  if(length(names(dat)[names(dat) == clustvar])==0){
-    stop(paste0("Cannot find a variable called ", clustvar, " in the dataset ", quote(dat), "."))
+  # Check variable name arguments
+  if (clustvar != "1"){
+    if (length(names(dat)[names(dat) == clustvar]) == 0){
+      stop(paste0("Cannot find a variable called ", clustvar,
+                  " in the dataset ", quote(dat), "."))
+    }}
+
+  if (length(names(dat)[names(dat) == yvar]) == 0){
+    stop(paste0("Cannot find a variable called ", yvar,
+                " in the dataset ", quote(dat), "."))
   }
 
-  if(length(names(dat)[names(dat) == yvar])==0){
-    stop(paste0("Cannot find a variable called ", yvar, " in the dataset ", quote(dat), "."))
-  }
-
-  if(!is.na(stratvar) & stratvar != ""){
-    if(length(names(dat)[names(dat) == stratvar])==0){
-      stop(paste0("Cannot find a variable called ", stratvar, " in the dataset ", quote(dat), "."))
+  if (!is.na(stratvar) & stratvar != ""){
+    if (length(names(dat)[names(dat) == stratvar]) == 0){
+      stop(paste0("Cannot find a variable called ", stratvar,
+                  " in the dataset ", quote(dat), "."))
     }
   }
 
-  if(!is.na(weightvar) & weightvar != ""){
-    if(length(names(dat)[names(dat) == weightvar])==0){
-      stop(paste0("Cannot find a variable called ", weightvar, " in the dataset ", quote(dat), "."))
+  if (!is.na(weightvar) & weightvar != ""){
+    if (length(names(dat)[names(dat) == weightvar]) == 0){
+      stop(paste0("Cannot find a variable called ", weightvar,
+                  " in the dataset ", quote(dat), "."))
     }
   }
 
-  ### Rename variables
+  # Create variables
+  dat$clustvar <- get(clustvar, dat)
+  dat$yvar <- get(yvar, dat)
 
-  names(dat)[names(dat) == clustvar] <- "clustvar"
-  names(dat)[names(dat) == yvar] <- "yvar"
-
-  if(!is.na(stratvar) & stratvar != ""){
-    names(dat)[names(dat) == stratvar] <- "stratvar"
+  if (!is.na(stratvar) & stratvar != ""){
+    dat$stratvar <- get(stratvar, dat)
   } else {
     print("Warning: stratvar was not specified. Treating the entire dataset as one stratum.")
     dat$stratvar <- 1
   }
 
-  if(!is.na(weightvar) & weightvar != ""){
-    names(dat)[names(dat) == weightvar] <- "weightvar"
+  if (!is.na(weightvar) & weightvar != ""){
+    dat$weightvar = get(weightvar,dat)
   } else {
     dat$weightvar <- 1
   }
 
-  # ^ This process will fail and error ("duplicate subscripts for columns") if there are already variables called clustvar, yvar, stratvar, or weightvar in the input dataset.
-
-  ### Check data and provide warnings if necessary
+  # Check data and provide warnings if necessary
   dat_orig <- dat
 
-  # Check "yvar" is either 0 or 1 -> records with yvar!=0 or 1 will be ignored
-  y_ind <- which(!(dat$yvar %in% c(0,1)))
-  if(length(y_ind) > 0) {
-    print(paste("Warning:", length(y_ind), "records had yvar without value 0 or 1, and therefore will be ignored."))
+  # Check "yvar" is either 0 or 1 -> records with yvar!= 0 or 1 will be ignored
+  y_ind <- which(!(dat$yvar %in% c(0, 1)))
+  if (length(y_ind) > 0) {
+    print(paste(
+      "Warning:", length(y_ind),
+      "records had yvar without value 0 or 1, and therefore will be ignored."))
   }
 
   # Check "weightvar" -> records with weightvar=missing or weightvar=0 will be ignored
-  wt_ind <- which(dat$weightvar %in% c(0,NA))
-  if(length(wt_ind) > 0) {
-    print(paste("Warning:", length(wt_ind), "records had weightvar with value 0 or missing.  These records will be ignored."))
+  wt_ind <- which(dat$weightvar %in% c(0, NA))
+  if (length(wt_ind) > 0) {
+    print(paste(
+      "Warning:", length(wt_ind),
+      "records had weightvar with value 0 or missing. These records will be ignored."))
   }
 
   # Check "clustvar" -> records with clustvar=missing will be ignored
   cl_ind <- which(is.na(dat$clustvar))
-  if(length(cl_ind)>0) {
-    print(paste("Warning:", length(cl_ind), "records had a missing clustvar value.  These records will be ignored."))
+  if (length(cl_ind) > 0) {
+    print(paste(
+      "Warning:", length(cl_ind),
+      "records had a missing clustvar value. These records will be ignored."))
   }
 
   # Subset data to ignore rows flagged above
-  if(length(c(y_ind,wt_ind,cl_ind))>0) {
-    dat <- dat[-c(y_ind,wt_ind,cl_ind),]
-    print(paste("Original dataset had",nrow(dat_orig),"rows.  The dataset used to make OP plot has",nrow(dat),"rows."))
+  if (length(c(y_ind, wt_ind, cl_ind)) > 0) {
+    dat <- dat[-c(y_ind, wt_ind, cl_ind),]
+    print(paste(
+      "Original dataset had", nrow(dat_orig),
+      "rows. The dataset used to make OP plot has", nrow(dat), "rows."))
   }
 
-  # Check if plot is saved to disk, that the platform specified is either wmf or pdf
-  if(!output_to_screen) {
-    check_platform <- platform=="wmf" | platform=="pdf" | platform=="png"
-    if(!check_platform) {
-      print(paste("Invalid platform specified: ",platform))
-      print("Either set it to wmf or pdf or png. For now, it will be set to wmf")
-      platform <- "wmf"
+  # Check if plot is saved to disk, that the platform specified is valid
+  if (!is.na(filename)) {
+    if (!platform %in% c("wmf", "pdf", "png")) {
+      print(paste("Invalid platform specified: ", platform))
+      print("Either set it to wmf or pdf or png. For now, it will be set to png")
+      platform <- "png"
     }
   }
 
-  ### Set up whether plot goes to screen or saved to file (either .wmf, .pdf, or .png)
+  # Check supplied colors
+  if (covgcategories == TRUE){
 
-  if(output_to_screen){windows(width = sizew, height = sizeh)}
+    invalid_colors <- NULL
 
-  if(!output_to_screen & platform=="wmf"){
-    win.metafile(file = paste0(filename, ".wmf"), width = sizew, height = sizeh)}
+    if (!vcqi_check_color(barcolorhigh1)){
+      invalid_colors <- c(invalid_colors, paste0("barcolorhigh1 = ", barcolorhigh1))
+      barcolorhigh1 <- "#67A9CF"
+    }
 
-  if(!output_to_screen & platform=="pdf"){
-    pdf(file = paste0(filename, ".pdf"), width = sizew, height = sizeh)}
+    if (!vcqi_check_color(barcolormid1)){
+      invalid_colors <- c(invalid_colors, paste0("barcolormid1 = ", barcolormid1))
+      barcolormid1 <- "#000080"
+    }
 
-  if(!output_to_screen & platform=="png"){
-    png(file = paste0(filename, ".png"), width = sizew, height = sizeh, units = "in", res = 576)}
+    if (!vcqi_check_color(barcolorlow1)){
+      invalid_colors <- c(invalid_colors, paste0("barcolorlow1 = ", barcolorlow1))
+      barcolorlow1 <- "#FF5B00"
+    }
 
-  ### Generate barwidth variable
-  # Generate variable with unique stratum/cluster combinations
-  dat <- within(dat, {stratum_cluster_factor <- factor(paste(dat$stratvar, dat$clustvar))})
+    if (!vcqi_check_color(barcolorhigh2)){
+      invalid_colors <- c(invalid_colors, paste0("barcolorhigh2 = ", barcolorhigh2))
+      barcolorhigh2 <- "#f0f0f0"
+    }
 
-  # Calculate the sum of the the weights by unique stratum/cluster combination
-  wclust_temp <- summaryBy(weightvar~stratum_cluster_factor, data=dat, FUN=sum)
+    if (!vcqi_check_color(barcolormid2)){
+      invalid_colors <- c(invalid_colors, paste0("barcolormid2 = ", barcolormid2))
+      barcolormid2 <- "#f0f0f0"
+    }
+
+    if (!vcqi_check_color(barcolorlow2)){
+      invalid_colors <- c(invalid_colors, paste0("barcolorlow2 = ", barcolorlow2))
+      barcolorlow2 <- "#f0f0f0"
+    }
+
+    if (!vcqi_check_color(linecolorhigh1)){
+      invalid_colors <- c(invalid_colors, paste0("linecolorhigh1 = ", linecolorhigh1))
+      linecolorhigh1 <- "gray"
+    }
+
+    if (!vcqi_check_color(linecolormid1)){
+      invalid_colors <- c(invalid_colors, paste0("linecolormid1 = ", linecolormid1))
+      linecolormid1 <- "gray"
+    }
+
+    if (!vcqi_check_color(linecolorlow1)){
+      invalid_colors <- c(invalid_colors, paste0("linecolorlow1 = ", linecolorlow1))
+      linecolorlow1 <- "gray"
+    }
+
+    if (!vcqi_check_color(linecolorhigh2)){
+      invalid_colors <- c(invalid_colors, paste0("linecolorhigh2 = ", linecolorhigh2))
+      linecolorhigh2 <- "gray"
+    }
+
+    if (!vcqi_check_color(linecolormid2)){
+      invalid_colors <- c(invalid_colors, paste0("linecolormid2 = ", linecolormid2))
+      linecolormid2 <- "gray"
+    }
+
+    if (!vcqi_check_color(linecolorlow2)){
+      invalid_colors <- c(invalid_colors, paste0("linecolorlow2 = ", linecolorlow2))
+      linecolorlow2 <- "gray"
+    }
+
+    if (!vcqi_check_color(nlinecolor)){
+      invalid_colors <- c(invalid_colors, paste0("nlinecolor = ", nlinecolor))
+      nlinecolor <- "black"
+    }
+
+    if (!vcqi_check_color(lowcovgthresholdlinecolor)){
+      invalid_colors <- c(
+        invalid_colors,
+        paste0("lowcovgthresholdlinecolor = ", lowcovgthresholdlinecolor))
+
+      lowcovgthresholdlinecolor <- "red"
+    }
+
+    if (!vcqi_check_color(highcovgthresholdlinecolor)){
+      invalid_colors <- c(
+        invalid_colors,
+        paste0("highcovgthresholdlinecolor = ", highcovgthresholdlinecolor))
+
+      highcovgthresholdlinecolor <- "red"
+    }
+
+  } else {
+
+    invalid_colors <- NULL
+
+    if (!vcqi_check_color(barcolor1)){
+      invalid_colors <- c(invalid_colors, paste0("barcolor1 = ", barcolor1))
+      barcolor1 <- "hotpink"
+    }
+
+    if (!vcqi_check_color(barcolor2)){
+      invalid_colors <- c(invalid_colors, paste0("barcolor2 = ", barcolor2))
+      barcolor2 <- "white"
+    }
+
+    if (!vcqi_check_color(linecolor1)){
+      invalid_colors <- c(invalid_colors, paste0("linecolor1 = ", linecolor1))
+      linecolor1 <- "gray"
+    }
+
+    if (!vcqi_check_color(linecolor2)){
+      invalid_colors <- c(invalid_colors, paste0("linecolor2 = ", linecolor2))
+      linecolor2 <- "gray"
+    }
+
+    if (!vcqi_check_color(nlinecolor)){
+      invalid_colors <- c(invalid_colors, paste0("nlinecolor = ", nlinecolor))
+      nlinecolor <- "black"
+    }
+
+  }
+
+  if (!is.null(invalid_colors)){
+    warning(paste0(
+      "Some opplot colors were not valid: ", paste(invalid_colors, collapse = "; "), ". ",
+      "Invalid colors have been replaced with default values."
+    ))
+  }
+
+  # Create the filename
+  filenamesave <- paste0(filename, ".", platform)
+
+  # Generate barwidth variable
+
+  ## 1. Create variable with unique stratum/cluster combinations
+  dat <- within(
+    dat, {stratum_cluster_factor <- factor(paste(dat$stratvar, dat$clustvar))})
+
+  ## 2. Calculate the sum of the the weights by unique stratum/cluster combination
+  wclust_temp <- doBy::summaryBy(weightvar ~ stratum_cluster_factor,
+                                 data = dat, FUN = sum)
   colnames(wclust_temp)[2] <- "wclust"
-  # Merge sum of weights with dat
-  dat2 <- merge(dat, wclust_temp, sort=FALSE)
 
-  # Calculate the sum of the the weights by unique stratum
-  wstrat_temp <- summaryBy(weightvar~stratvar, data=dat, FUN=sum)
+  ## 3. Merge sum of weights with dat
+  dat2 <- merge(dat, wclust_temp, sort = FALSE)
+
+  ## 4. Calculate the sum of the the weights by unique stratum
+  wstrat_temp <- doBy::summaryBy(weightvar ~ stratvar, data = dat, FUN = sum)
   colnames(wstrat_temp)[2] <- "wstrat"
-  # Merge sum of weights with dat2
+
+  ## 5. Merge sum of weights with dat2
   dat3 <- merge(dat2, wstrat_temp, sort=FALSE)
 
-  # Calculate barwidth variable
+  ## 6. Calculate barwidth variable
   dat3$barwidth <- 100 * dat3$wclust/dat3$wstrat
 
-  ### Generate barheight variable
+  # Generate barheight variable
   dat3$yweight <- dat3$yvar * dat3$weightvar
-  yweight_sum_df <- summaryBy(yweight~stratum_cluster_factor, data=dat3, FUN=sum)
+  yweight_sum_df <- doBy::summaryBy(
+    yweight ~ stratum_cluster_factor, data = dat3, FUN = sum)
   colnames(yweight_sum_df)[2] <- "wsum1"
+
   # Merge sum of weights with dat3
-  dat4 <- merge(dat3, yweight_sum_df, sort=FALSE)
+  dat4 <- merge(dat3, yweight_sum_df, sort = FALSE)
   dat4$barheight <- round(100*dat4$wsum1/dat4$wclust)
 
   # Calculate the sum of the the respondents by unique stratum/cluster combination
-  # Note: This variable will only be used if plotn==T
+  # Note: This variable will only be used if plotn == TRUE
   dat4$one <- 1 # make a col of 1's for summing in the next line...
-  nresp_temp <- summaryBy(one~stratum_cluster_factor, data=dat4, FUN=sum)
+  nresp_temp <- doBy::summaryBy(one ~ stratum_cluster_factor, data = dat4, FUN = sum)
   colnames(nresp_temp)[2] <- "nresp"
+
   # Merge sum of respondents per stratum/cluster with dat
-  dat5 <- merge(dat4,nresp_temp,sort=F)
+  dat5 <- merge(dat4, nresp_temp, sort = FALSE)
 
-  ### Organize data for plotting
-  # Keep 1 obs for each stratum/cluster
-  dat5_sorted <- dat5[order(dat5$stratvar,dat5$clustvar),]
-  one_obs <- dat5_sorted[!duplicated(dat5_sorted[names(dat5_sorted)=="stratum_cluster_factor"]),]
+  # Organize data for plotting
 
-  # Keep stratum of interest
-  if(stratum!="") {
-    if(!is.na(stratvar) & stratvar != ""){
-    one_obs_subset <- one_obs[which(one_obs$stratvar==stratum),]
+  ## Keep 1 observation for each stratum/cluster
+  dat5_sorted <- dat5[order(dat5$stratvar, dat5$clustvar),]
+  one_obs <- dat5_sorted[!duplicated(dat5_sorted[names(dat5_sorted) == "stratum_cluster_factor"]),]
+
+  ## Keep stratum of interest
+  if (stratum!="") {
+    if (!is.na(stratvar) & stratvar != ""){
+      one_obs_subset <- one_obs[which(one_obs$stratvar == stratum),]
     } else {
-      print(paste0("Warning: cannot show results for stratum = ", stratum, " because stratvar is not defined. All observations are used in plot."))
+      print(paste0(
+        "Warning: cannot show results for stratum = ", stratum,
+        " because stratvar is not defined. All observations are used in plot."))
       one_obs_subset <- one_obs
     }
   } else {
@@ -192,61 +367,134 @@ opplot <- function(
     one_obs_subset <- one_obs
   }
 
-  # Sort data (descending) by barheight then by barwidth
-  to_plot <- one_obs_subset[order(-one_obs_subset$barheight,-one_obs_subset$barwidth,-one_obs_subset$nresp,one_obs_subset$clustvar),]
-  to_plot$barheight2 <- 100-to_plot$barheight
+  ## Sort data (descending) by barheight then by barwidth
+  to_plot <- one_obs_subset[order(
+    -one_obs_subset$barheight,
+    -one_obs_subset$barwidth,
+    -one_obs_subset$nresp,
+    one_obs_subset$clustvar),]
 
-  ### Make OPP
-  if(plotn==T) {
-    par(mar = c(5, 4, 4, 4) + 0.3)  # Leave space for second y axis
+  to_plot$barheight2 <- 100 - to_plot$barheight
+
+  ## Add left point and right point to the dataset
+  left <- c(rep(0, nrow(to_plot)))
+  width <- to_plot$barwidth
+  right <- c(width[1], rep(0, (nrow(to_plot) - 1)))
+
+  if (nrow(to_plot) > 1){
+    for (i in 2:nrow(to_plot)){
+      left[i] = right[i - 1]
+      right[i] = left[i] + width[i]
+    }
   }
 
-  counts <- as.matrix(rbind(to_plot$barheight,to_plot$barheight2))
-  barplot(height=counts,width=to_plot$barwidth,space=0,beside=FALSE,col=c(barcolor1,barcolor2),
-          cex.main=1.5, main=title,ylab=ylabel,las=2,border=c(linecolor1,linecolor2),
-          font.main=1,axes=F)
-  axis(2,labels=seq(from=ymin,to=ymax,by=yby),at=seq(from=ymin,to=ymax,by=yby),las=2)
-  mtext(side=3, subtitle, cex=1, line=.35)
-  mtext(side=1, footnote, cex=.8, line=.4, adj=0)
-  box()
+  to_plot <- dplyr::mutate(to_plot, left = left, right = right)
 
-  # Check if user wants to plot the number of respondents (N) (plotn option),
-  #  Add second axis with n's to the plot if plotn==T
-  if(plotn==T) {
-    # Calculate ymax2 for second y axis
+  opplot_footnote <- stringr::str_wrap(footnote, width = 100)
+
+  # Make organ pipe plot
+  if (plotn == TRUE) {
+    par(mar = c(5, 4, 4, 4) + 0.3)  # Leave space for second y axis
+
     ymax2_temp <- max(one_obs_subset$nresp)
     ymax2 <- yround2 * ceiling((ymax2_temp+1)/yround2)
 
-    # Calculate cumulative sum of sorted barwidth variable...for plotn stairstep look
-    to_plot$cumsum_barwidth <- cumsum(to_plot$barwidth)
+    # creating new dataset for the geom_step
+    pointdata <- data.frame(
+      xpoint = c(to_plot$left,
+                 to_plot$right[nrow(to_plot)]),
+      ypoint = c(to_plot$nresp*(ymax/ymax2),
+                 to_plot$nresp[nrow(to_plot)]*(ymax/ymax2)))
 
-    # Add an extra row onto the dataset to make the x values work out correctly when plotted
-    to_plot[nrow(to_plot)+1,] <- NA
-
-    # Shift the cumulative bar width up by one observation to make the x values work out correctly
-    to_plot$cumsum_barwidth <- c(0,to_plot$cumsum_barwidth[1:(nrow(to_plot)-1)])
-
-    # Repeat the last nresp obs to the "new" last row so nline extends through last cluster
-    to_plot$nresp[nrow(to_plot)] <- to_plot$nresp[nrow(to_plot)-1]
-
-    # Add second y axis as new plot on top of barchart plot
-    par(new = T)
-    plot(to_plot$cumsum_barwidth, to_plot$nresp, type="s", axes=FALSE, bty="n",
-         lty=nlinepattern, col=nlinecolor, lwd=nlinewidth, xlab="", ylab="",ylim=c(0,ymax2))
-    axis(4,labels=seq(from=0,to=ymax2,by=yround2),at=seq(from=0,to=ymax2,by=yround2),las=2)
-    mtext(side = 4, line=2, ytitle2)
   }
 
-  # If the user has asked for underlying data to be saved, then trim down to a small
-  # dataset that summarizes what is shown in the bars; this is to help users
-  # identify the clusterid of a particular bar in the figure; the order in which
-  # clusterids appear in the saved dataset is the same order they appear in the plot
-  if(savedata!="") {
+  plot_result <- ggplot2::ggplot(to_plot) +
+    {if (covgcategories == FALSE) geom_rect(
+      aes(xmin = left, xmax = right, ymin = 0, ymax = barheight),
+      fill = barcolor1, color = linecolor1
+    )} +
+    {if (covgcategories == FALSE) geom_rect(
+      aes(xmin = left, xmax = right, ymin = barheight, ymax = 100),
+      fill = barcolor2, color = linecolor2
+    )} +
+    # Categorized coverage: high, medium, and low bars - upper and lower
+    {if (covgcategories == TRUE) geom_rect(
+      data = filter(to_plot, barheight >= highcovgthreshold),
+      aes(xmin = left, xmax = right, ymin = 0, ymax = barheight),
+      fill = barcolorhigh1, color = linecolorhigh1
+    )} +
+    {if (covgcategories == TRUE) geom_rect(
+      data = filter(to_plot, barheight >= highcovgthreshold),
+      aes(xmin = left, xmax = right, ymin = barheight, ymax = 100),
+      fill = barcolorhigh2, color = linecolorhigh2
+    )} +
+    {if (covgcategories == TRUE) geom_rect(
+      data = filter(to_plot, barheight < highcovgthreshold & barheight > lowcovgthreshold),
+      aes(xmin = left, xmax = right, ymin = 0, ymax = barheight),
+      fill = barcolormid1, color = linecolormid1
+    )} +
+    {if (covgcategories == TRUE) geom_rect(
+      data = filter(to_plot, barheight < highcovgthreshold & barheight > lowcovgthreshold),
+      aes(xmin = left, xmax = right, ymin = barheight, ymax = 100),
+      fill = barcolormid2, color = linecolormid2
+    )} +
+    {if (covgcategories == TRUE) geom_rect(
+      data = filter(to_plot, barheight <= lowcovgthreshold),
+      aes(xmin = left, xmax = right, ymin = 0, ymax = barheight),
+      fill = barcolorlow1, color = linecolorlow1
+    )} +
+    {if (covgcategories == TRUE) geom_rect(
+      data = filter(to_plot, barheight <= lowcovgthreshold),
+      aes(xmin = left, xmax = right, ymin = barheight, ymax = 100),
+      fill = barcolorlow2, color = linecolorlow2
+    )} +
+    {if (covgcategories == TRUE & lowcovgthresholdline == TRUE) geom_hline(
+      aes(yintercept = lowcovgthreshold), color = lowcovgthresholdlinecolor
+    )} +
+    {if (covgcategories == TRUE & highcovgthresholdline == TRUE) geom_hline(
+      aes(yintercept = highcovgthreshold), color = highcovgthresholdlinecolor
+    )} +
+
+    labs(title = title,
+         subtitle = subtitle,
+         caption = opplot_footnote) +
+    theme_bw() +
+    theme(panel.border = element_rect(color = "black"),
+          panel.grid.major = element_blank(),
+          panel.grid.minor = element_blank(),
+          axis.title.x = element_blank(),
+          axis.text.x = element_blank(),
+          axis.ticks.x = element_blank(),
+          plot.title = element_text(hjust = 0.5),
+          plot.subtitle = element_text(hjust = 0.5),
+          plot.caption = element_text(hjust = 0)
+    ) +
+    {if (plotn == FALSE) scale_y_continuous(name = ylabel, breaks = seq(ymin, ymax, by = yby))} +
+    {if (plotn == TRUE) scale_y_continuous(
+      name = ylabel, breaks = seq(ymin, ymax, by = yby),
+      sec.axis = sec_axis(~./(ymax/ymax2), name = ylabel2,
+                          breaks = seq(0, ymax2, yround2)))} +
+    {if (plotn == TRUE) geom_step(
+      pointdata, mapping = aes(x = xpoint, y = ypoint),
+      color = nlinecolor, linewidth = nlinewidth,linetype = nlinepattern)} +
+    {if (plotn == TRUE) theme(axis.title.y.right = element_text(angle = 90))}
+
+  if (!is.na(filename)){
+    ggsave(filenamesave, plot_result, width = sizew, height = sizeh, units = "in")
+  }
+
+  # If the user has asked for underlying data to be saved, then trim down to a
+  # small dataset that summarizes what is shown in the bars; this is to help
+  # users identify the clusterid of a particular bar in the figure; the order in
+  # which clusterids appear in the saved dataset is the same order they appear
+  # in the plot
+
+  if (!is.na(savedata)) {
     # First, save 10 variables as vectors
-    yvar_rep <- rep(yvar,length(to_plot$yvar))
-    stratvar_rep <- rep(stratvar,length(to_plot$yvar))
-    stratum_rep <- rep(stratum,length(to_plot$yvar))
-    cluster_rep <- rep(clustvar,length(to_plot$yvar))
+    yvar_rep <- rep(yvar, length(to_plot$yvar))
+    stratvar_rep <- rep(stratvar, length(to_plot$yvar))
+    stratum_rep <- rep(stratum, length(to_plot$yvar))
+    cluster_rep <- rep(clustvar, length(to_plot$yvar))
     clusterid <- to_plot$clustvar
     n_respondents <- to_plot$nresp
     barorder <- c(1:length(to_plot$yvar))
@@ -263,16 +511,26 @@ opplot <- function(
     to_save <- to_save[!is.na(to_save$clusterid),]
 
     # Re-name the *_rep variables
-    colnames(to_save)[colnames(to_save)=="yvar_rep"] <- "yvar"
-    colnames(to_save)[colnames(to_save)=="stratvar_rep"] <- "stratvar"
-    colnames(to_save)[colnames(to_save)=="stratum_rep"] <- "stratum"
-    colnames(to_save)[colnames(to_save)=="cluster_rep"] <- "cluster"
+    colnames(to_save)[colnames(to_save) == "yvar_rep"] <- "yvar"
+    colnames(to_save)[colnames(to_save) == "stratvar_rep"] <- "stratvar"
+    colnames(to_save)[colnames(to_save) == "stratum_rep"] <- "stratum"
+    colnames(to_save)[colnames(to_save) == "cluster_rep"] <- "cluster"
 
-    # Save data.frame to disk (as a .csv)
-    write.csv(to_save, file = file.path(paste0(savedata, ".csv")), row.names = FALSE)
+    # Save data.frame to disk (as a .csv or a .rds)
+    if (savedatatype == "rds") {
+      saveRDS(to_save, file = file.path(paste0(savedata, ".rds")))
+    } else if (savedatatype == "csv") {
+      write.csv(to_save, file = file.path(paste0(savedata, ".csv")),
+                row.names = FALSE)
+    } else {
+      print("The savedatatype argument must be either csv or rds. Defaulting to saving as a CSV.")
+      write.csv(to_save, file = file.path(paste0(savedata, ".csv")),
+                row.names = FALSE)
+    }
   }
 
-  # Close plot window if plot is saved to disk
-  if(!output_to_screen) dev.off()
+  if (output_to_screen %in% TRUE){
+    plot_result
+  }
 
 }


### PR DESCRIPTION
Bringing this standalone version of opplot up to date: 
- updating internal data processing to avoid some unnecessary complexity and steps that are error-prone 
- adding new features implemented in vcqiR::opplot 
- adding more checks of user arguments, including validity of colors, and reverting to defaults where appropriate 
- allowing users to save plot to disc _and_ preview plot in R in a given opplot call

Examples in the demo file have been retooled to include adjusting the new options. 

Note that this version of the function does _not_ include options to add coverage, DEFF, and ICC to the plot footnote. In the vcqiR version of opplot, those options rely on having svypd available, so I haven't tackled bringing those options into this standalone function yet. 